### PR TITLE
Use eldoc-highlight-function-argument face.

### DIFF
--- a/c-eldoc.el
+++ b/c-eldoc.el
@@ -248,7 +248,7 @@ T1 and T2 are time values (as returned by `current-time' for example)."
       (when (and pos
                  (setq pos (string-match "[^ ,()]" arguments pos)))
         (add-text-properties pos (string-match "[,)]" arguments pos)
-                             '(face bold) arguments))
+                             '(face eldoc-highlight-function-argument) arguments))
       arguments)))
 
 ;;;###autoload


### PR DESCRIPTION
eldoc-highlight-function-argument seems to be the right face to use to highlight the current function argument.
