### PR TITLE
Fix function search regular expression

### DIFF
--- a/c-eldoc.el
+++ b/c-eldoc.el
@@ -256,7 +256,7 @@ T1 and T2 are time values (as returned by `current-time' for example)."
   "Returns documentation string for the current symbol."
   (let* ((current-function-cons (c-eldoc-function-and-argument (- (point) 1000)))
          (current-function (car current-function-cons))
-         (current-function-regexp (concat "[ \t\n]*[0-9a-zA-Z]+[ \t\n*]+" current-function "[ \t\n]*("))
+         (current-function-regexp (concat "[[:alnum:]_()[:space:]]+[[:space:]]+" current-function "[[:space:]]*("))
          (current-macro-regexp (concat "#define[ \t\n]+" current-function "[ \t\n]*("))
          (current-buffer (current-buffer))
          (tag-buffer)


### PR DESCRIPTION
I fixed a regular expression that searches for the function in the pre-processed file so it catches function declarations like 

    int __attribute__((__cdecl__)) printf(const char * __restrict__ _Format,...);
