### PR TITLE
Fix current-function-regexp in c-eldoc-print-current-symbol-info.

### DIFF
--- a/c-eldoc.el
+++ b/c-eldoc.el
@@ -256,7 +256,7 @@ T1 and T2 are time values (as returned by `current-time' for example)."
   "Returns documentation string for the current symbol."
   (let* ((current-function-cons (c-eldoc-function-and-argument (- (point) 1000)))
          (current-function (car current-function-cons))
-         (current-function-regexp (concat "[[:alnum:]_()[:space:]]+[[:space:]]+" current-function "[[:space:]]*("))
+         (current-function-regexp (concat "[[:alnum:]_()[:space:]]+[[:space:]*&]+" current-function "[[:space:]]*("))
          (current-macro-regexp (concat "#define[ \t\n]+" current-function "[ \t\n]*("))
          (current-buffer (current-buffer))
          (tag-buffer)


### PR DESCRIPTION
Looks like the current regexp not match for functions returning pointers(or references in c++).
Example:
```c
extern void *malloc (size_t __size) __attribute__ ((__nothrow__ , __leaf__)) __attribute__ ((__malloc__)) ;
```